### PR TITLE
Ensemble corrector: bugfix by retracing our steps

### DIFF
--- a/corrections/BaseCorrector.py
+++ b/corrections/BaseCorrector.py
@@ -544,10 +544,6 @@ class BaseCorrector(object):
 				hdu['LIGHTCURVE'].header['CORRMET'] = (CorrMethod, 'Lightcurve correction method')
 				hdu['LIGHTCURVE'].header['CORRVER'] = (__version__, 'Version of correction pipeline')
 
-				# Set additional headers so that the saved light curve can be opened using `lightkurve`
-				hdu['PRIMARY'].header['MISSION'] = 'TESS'
-				hdu['PRIMARY'].header['CREATOR'] = 'LIGHTCURVE'
-
 				# Set additional headers provided by the individual methods:
 				if lc.meta['additional_headers']:
 					for key, value in lc.meta['additional_headers'].items():

--- a/corrections/BaseCorrector.py
+++ b/corrections/BaseCorrector.py
@@ -495,7 +495,7 @@ class BaseCorrector(object):
 		.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
 		.. codeauthor:: Mikkel N. Lund <mikkelnl@phys.au.dk>
 		"""
-		
+
 		logger = logging.getLogger(__name__)
 
 		# Find the name of the correction method based on the class name:
@@ -528,16 +528,14 @@ class BaseCorrector(object):
 				save_file = os.path.join(output_folder, os.path.dirname(fname), filename)
 
 			shutil.copy(os.path.join(self.input_folder, fname), save_file)
-			logger.debug("Saving lightcurve to {}".format(save_file))
+			logger.debug("Saving lightcurve to '%s'", save_file)
 
 			# Change permission of copied file to allow the addition of the corrected lightcurve
 			os.chmod(save_file, 0o640)
 
 			# Open the FITS file to overwrite the corrected flux columns:
 			with fits.open(save_file, mode='update') as hdu:
-				logger.debug("Updating file: {}".format(save_file))
 				# Overwrite the corrected flux columns:
-				logger.debug("Status of correction: {}".format((np.isnan(np.asarray(lc.flux))).tolist().count(False)))
 				hdu['LIGHTCURVE'].data['FLUX_CORR'] = lc.flux
 				hdu['LIGHTCURVE'].data['FLUX_CORR_ERR'] = lc.flux_err
 				hdu['LIGHTCURVE'].data['QUALITY'] = lc.quality

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -28,7 +28,8 @@ class EnsembleCorrector(BaseCorrector):
 	#----------------------------------------------------------------------------------------------
 	def __init__(self, *args, **kwargs):
 		"""
-		Initialize the correction object
+		Initialize the correction object.
+
 		Parameters:
 			*args: Arguments for the BaseCorrector class
 			**kwargs: Keyword Arguments for the BaseCorrector class
@@ -118,7 +119,10 @@ class EnsembleCorrector(BaseCorrector):
 		Add a given target to the ensemble list
 
 		Parameters:
-			next_star_lc (`TESSLightCurve` object): Lightcurve object for target obtained from :func:`load_lightcurve`.
+			lc (`TESSLightCurve` object): Lightcurve for target obtained
+				from :func:`load_lightcurve`.
+			next_star_lc (`TESSLightCurve` object): Lightcurve for star to add to ensemble
+				obtained from :func:`load_lightcurve`.
 			temp_list (list): List of TIC ID's for ensemble members as Strings
 			lc_ensemble (list): List of ensemble members flux as ndarrays
 
@@ -174,9 +178,9 @@ class EnsembleCorrector(BaseCorrector):
 			lc_corr (`TESSLightCurve` object): Lightcurve object which stores in `flux` the ensemble
 				corrected flux values.
 
-        Returns:
-            lc_corr (`TESSLightCurve` object): The updated object with corrected flux values;
-                the object must be returned explicitly because passed object values do not update in place
+		Returns:
+			lc_corr (`TESSLightCurve` object): The updated object with corrected flux values;
+				the object must be returned explicitly because passed object values do not update in place
 
 		.. codeauthor:: Lindsey Carboneau
 		.. codeauthor:: Derek Buzasi
@@ -253,6 +257,7 @@ class EnsembleCorrector(BaseCorrector):
 		# Define variables to use in the loop to build the ensemble of stars
 		# List of star indexes to be included in the ensemble
 		temp_list = []
+		lc_ensemble = []
 		bzetas = []
 		# Test values store current best correction for testing vs. additional ensemble members
 		# NOTE: this might be done more efficiently with further functionalization of the loop below and updated loop bounds/conditions!
@@ -263,8 +268,6 @@ class EnsembleCorrector(BaseCorrector):
 
 		# Start loop to build ensemble
 		ensemble_start = default_timer()
-		lc_ensemble = []
-		mtarget_flux = lc.flux - target_flux_median
 
 		# Loop through the neighbors to build the ensemble:
 		for next_star_index in nearby_stars:
@@ -296,7 +299,7 @@ class EnsembleCorrector(BaseCorrector):
 					if fom is np.nan:
 						# the first time we hit the minimum ensemble size, try to correct the target
 						# storing all these as 'test' - we'll revert to these values if adding the next star doesn't 'surpass the test'
-                        # `deepcopy` because otherwise it uses pointers and overwrites the value we need
+						# `deepcopy` because otherwise it uses pointers and overwrites the value we need
 						test_corr = self.apply_ensemble(lc, lc_ensemble, lc_corr)
 						test_ens = copy.deepcopy(lc_ensemble)
 						test_list = copy.deepcopy(temp_list)
@@ -353,8 +356,7 @@ class EnsembleCorrector(BaseCorrector):
 		lc_corr.meta['additional_headers']['ENS_DREL'] = (drange_relfactor, 'Limit on relative diff. range')
 		lc_corr.meta['additional_headers']['ENS_RLIM'] = (frange_lim, 'Limit on flux range metric')
 
-
-        # Replace removed points with NaN's so the info can be saved to the FITS - without this, the BaseCorrector will raise an `IndexError`
+		# Replace removed points with NaN's so the info can be saved to the FITS - without this, the BaseCorrector will raise an `IndexError`
 		if len(lc_corr.flux) != len(og_time):
 			fix_flux = np.asarray(lc_corr.flux.copy())
 			fix_err = np.asarray(lc_corr.flux_err.copy())

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -292,7 +292,9 @@ class EnsembleCorrector(BaseCorrector):
 			# drange of the target (to ensure exclusion of relatively noisy stars), and frange less than 0.03 (to exclude highly variable stars)
 			if drange < drange_lim and drange < drange_relfactor*lc.meta['drange'] and frange < frange_lim:
 
+				# Add the star to the ensemble:
 				self.add_ensemble_member(lc, next_star_lc, next_star_index, temp_list, lc_ensemble, bzetas)
+
 				# Pause the loop if we have reached the desired number of stars, and check the correction:
 				if len(temp_list) >= star_count:
 
@@ -310,7 +312,6 @@ class EnsembleCorrector(BaseCorrector):
 						# NOTE: I think this can be more efficiently, but I'm scared to 'fix' what is currently working - LC
 						########
 						continue
-
 					else:
 						# see if one more member makes the ensemble 'surpass the test'
 						lc_corr = self.apply_ensemble(lc, lc_ensemble, lc_corr)

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -292,7 +292,9 @@ class EnsembleCorrector(BaseCorrector):
 			# drange of the target (to ensure exclusion of relatively noisy stars), and frange less than 0.03 (to exclude highly variable stars)
 			if drange < drange_lim and drange < drange_relfactor*lc.meta['drange'] and frange < frange_lim:
 
+				# Add the star to the ensemble:
 				self.add_ensemble_member(lc, next_star_lc, temp_list, lc_ensemble, bzetas)
+
 				# Pause the loop if we have reached the desired number of stars, and check the correction:
 				if len(temp_list) >= star_count:
 
@@ -366,8 +368,8 @@ class EnsembleCorrector(BaseCorrector):
 				fix_flux = np.insert(fix_flux, ind, np.nan)
 				fix_err = np.insert(fix_err, ind, np.nan)
 
-			lc_corr.flux = fix_flux.tolist()
-			lc_corr.flux_err = fix_err.tolist()
+			lc_corr.flux = fix_flux
+			lc_corr.flux_err = fix_err
 			lc_corr.time = og_time
 
 		#------------------------------------------------------------------------------------------

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -280,7 +280,7 @@ class EnsembleCorrector(BaseCorrector):
 			drange = nanstd(np.diff(next_star_lc.flux)) / next_star_lc.meta['task']['mean_flux']
 
 			logger.debug("drange=%f, frange=%f", drange, frange)
-			logger.debug("lc size: %f", len(next_star_lc.flux))
+			logger.debug("lc size: %f", len(next_star_lc))
 
 			# Stars are added to ensemble if they fulfill the requirements. These are (1) drange less than min_range, (2) drange less than 10 times the
 			# drange of the target (to ensure exclusion of relatively noisy stars), and frange less than 0.03 (to exclude highly variable stars)
@@ -331,7 +331,7 @@ class EnsembleCorrector(BaseCorrector):
 			return None, STATUS.ERROR
 
 		logger.info("Build ensemble, Time: %f", default_timer()-ensemble_start)
-		logger.debug("len(lc) vs len(ens): %f vs %f", len(lc.flux), len(lc_ensemble[0]))
+		logger.debug("len(lc) vs len(ens): %f vs %f", len(lc), len(lc_ensemble[0]))
 
 		# Convert to parts-per-million:
 		corr_median = nanmedian(lc_corr.flux)

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -114,7 +114,7 @@ class EnsembleCorrector(BaseCorrector):
 		return nearby_stars
 
 	#----------------------------------------------------------------------------------------------
-	def add_ensemble_member(self, lc, next_star_lc, next_star_index, temp_list, lc_ensemble, bzetas):
+	def add_ensemble_member(self, lc, next_star_lc, temp_list, lc_ensemble, bzetas):
 		"""
 		Add a given target to the ensemble list
 
@@ -161,7 +161,7 @@ class EnsembleCorrector(BaseCorrector):
 
 		ens_flux = ens_flux + res.x
 
-		temp_list.append(next_star_index) # , next_star_lc.copy()
+		temp_list.append(next_star_lc.targetid) # , next_star_lc.copy()
 		bzetas.append(float(res.x))
 		lc_ensemble.append(ens_flux/nanmedian(ens_flux))
 		# temp_list and lc_ensemble are lists, and don't need to be returned because append() updates in place
@@ -292,13 +292,11 @@ class EnsembleCorrector(BaseCorrector):
 			# drange of the target (to ensure exclusion of relatively noisy stars), and frange less than 0.03 (to exclude highly variable stars)
 			if drange < drange_lim and drange < drange_relfactor*lc.meta['drange'] and frange < frange_lim:
 
-				# Add the star to the ensemble:
-				self.add_ensemble_member(lc, next_star_lc, next_star_index, temp_list, lc_ensemble, bzetas)
-
+				self.add_ensemble_member(lc, next_star_lc, temp_list, lc_ensemble, bzetas)
 				# Pause the loop if we have reached the desired number of stars, and check the correction:
 				if len(temp_list) >= star_count:
 
-					if fom is np.nan:
+					if np.isnan(fom):
 						# the first time we hit the minimum ensemble size, try to correct the target
 						# storing all these as 'test' - we'll revert to these values if adding the next star doesn't 'surpass the test'
 						# `deepcopy` because otherwise it uses pointers and overwrites the value we need

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -12,25 +12,33 @@ The ensemble photometry detrending class.
 
 import numpy as np
 import os.path
-from bottleneck import nanmedian, nanstd, nansum, ss
+from bottleneck import nanmedian
+#import scipy.interpolate
+#import scipy.optimize as sciopt
 from timeit import default_timer
 import logging
-from scipy.optimize import minimize # minimize_scalar
+from scipy.optimize import minimize
+#from scipy.optimize import minimize_scalar
 from sklearn.neighbors import NearestNeighbors
 import copy
 from .plots import plt, save_figure
-from .quality import TESSQualityFlags
 from . import BaseCorrector, STATUS
 
-#--------------------------------------------------------------------------------------------------
+
 class EnsembleCorrector(BaseCorrector):
+	"""
+	DOCSTRING
+	"""
 
 	#----------------------------------------------------------------------------------------------
 	def __init__(self, *args, **kwargs):
 		"""
-		Initialize the correction object.
+		Initialize the correction object
+		Parameters:
+			*args: Arguments for the BaseCorrector class
+			**kwargs: Keyword Arguments for the BaseCorrector class
 		"""
-		super().__init__(*args, **kwargs)
+		super(self.__class__, self).__init__(*args, **kwargs)
 
 		logger = logging.getLogger(__name__)
 		self.debug = logger.isEnabledFor(logging.DEBUG)
@@ -49,31 +57,22 @@ class EnsembleCorrector(BaseCorrector):
 
 		Returns:
 			list: List of `priority` identifiers of the `n_neighbors` nearest stars.
-				These values can be passed directly to :func:`load_lightcurve` to load the
-				lightcurves of the targets.
+				Thest values can be passed directly to :func:`load_lightcurve` to load the lightcurves of the targets.
 
 		.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
 		"""
 
-		sector = lc.sector
 		camera = lc.camera
 		ccd = lc.ccd
 		ds = 'ffi' if lc.meta["task"]["datasource"] == 'ffi' else 'tpf'
-		key = (sector, ds, camera, ccd)
+		key = (ds, camera, ccd)
 
 		# Check if the NearestNeighbors object already exists for this camera and CCD.
 		# If not create it, and store it for later use.
 		if key not in self._nearest_neighbors:
 			# StarID, pixel positions are retrieved from the database:
 			select_params = ["todolist.priority", "pos_row", "pos_column"]
-			search_params = [
-				'status={:d}'.format(STATUS.OK.value), # Only including targets with status=OK from photometry
-				"(method IS NULL OR method='aperture')", # Only including aperature photometry targets
-				"camera={:d}".format(camera),
-				"ccd={:d}".format(ccd),
-				"sector={:d}".format(sector),
-				"mean_flux>0"
-			]
+			search_params = ["camera={:d}".format(camera), "ccd={:d}".format(ccd), "mean_flux>0"]
 			if ds == 'ffi':
 				search_params.append("datasource = 'ffi'")
 			else:
@@ -97,7 +96,7 @@ class EnsembleCorrector(BaseCorrector):
 		X = np.array([[lc.meta['task']['pos_row'], lc.meta['task']['pos_column']]])
 
 		# Use the NearestNeighbor object to find the targets closest to the main target:
-		distance_index = nn.kneighbors(X, n_neighbors=min(n_neighbors+1, len(priority)), return_distance=False)
+		distance_index = nn.kneighbors(X, n_neighbors=n_neighbors+1, return_distance=False)
 		nearby_stars = priority[distance_index.flatten()]
 
 		# Remove the main target from the list, if it is included:
@@ -105,34 +104,31 @@ class EnsembleCorrector(BaseCorrector):
 		nearby_stars = nearby_stars[indx]
 
 		# Return the list of nearby stars:
+		print(nearby_stars)
 		return nearby_stars
 
 	#----------------------------------------------------------------------------------------------
-	def add_ensemble_member(self, lc, next_star_lc):
+	def add_ensemble_member(self, lc, next_star_lc, next_star_index, temp_list, lc_ensemble, bzetas):
 		"""
-		Add a given target to the ensemble list
+		Add a given target to the ensemble list 
 
 		Parameters:
-			lc (`TESSLightCurve` object): Lightcurve for target obtained
-				from :func:`load_lightcurve`.
-			next_star_lc (`TESSLightCurve` object): Lightcurve for star to add to ensemble
-				obtained from :func:`load_lightcurve`.
-
-		Returns:
-			ndarray: Lightcurve (flux) to add to ensemble.
+			next_star_lc (`TESSLightCurve` object): Lightcurve object for target obtained from :func:`load_lightcurve`.
+			temp_list (list): List of TIC ID's for ensemble members as Strings
+			lc_ensemble (list): List of ensemble members flux as ndarrays
 
 		.. codeauthor:: Lindsey Carboneau
 		.. codeauthor:: Derek Buzasi
 		"""
 		# Median subtracted flux of target and ensemble candidate
-		target_flux_median = lc.meta['task']['mean_flux']
+		target_flux_median = np.nanmedian(lc.flux)
 		mtarget_flux = lc.flux - target_flux_median
 		ens_flux = next_star_lc.flux
-		mens_flux = ens_flux - nanmedian(ens_flux)
+		mens_flux = ens_flux - np.nanmedian(ens_flux)
 
 		# 2 sigma
-		ens2sig = 2 * nanstd(mens_flux)
-		targ2sig = 2 * nanstd(mtarget_flux)
+		ens2sig = 2 * np.std(mens_flux)
+		targ2sig = 2 * np.std(mtarget_flux)
 
 		# absolute balue
 		abstarg = np.absolute(mtarget_flux)
@@ -143,34 +139,37 @@ class EnsembleCorrector(BaseCorrector):
 			clip_target_flux = np.where((abstarg < targ2sig) & (absens < ens2sig), mtarget_flux, 1)
 			clip_ens_flux = np.where((abstarg < targ2sig) & (absens < ens2sig), mens_flux, 1)
 
-		args = (clip_ens_flux + nanmedian(ens_flux), clip_target_flux + target_flux_median)
+		args = tuple((clip_ens_flux + nanmedian(ens_flux), clip_target_flux + target_flux_median))
 
 		def func1(scaleK, *args):
-			temp = (args[1]/nanmedian(args[1])) - ((args[0]+scaleK)/nanmedian(args[0]+scaleK))
-			temp -= nanmedian(temp)
-			return ss(temp)
+			temp = (((args[0]+scaleK)/np.median(args[0]+scaleK))-1)-((args[1]/np.median(args[1]))-1)
+			temp = (args[1]/np.median(args[1])) - ((args[0]+scaleK)/np.median(args[0]+scaleK))
+			temp = temp - np.median(temp)
+			return np.sum(np.square(temp))
 
-		res = minimize(func1, 100, args=args, method='Powell')
-		bzeta = float(res.x)
+		scale0 = 100
+		res = minimize(func1, scale0, args=args, method='Powell')
 
-		ens_flux = ens_flux + bzeta
+		ens_flux = ens_flux + res.x
 
-		return ens_flux/nanmedian(ens_flux), bzeta
-
+		temp_list.append(next_star_index) # , next_star_lc.copy()
+		bzetas.append(float(res.x))
+		lc_ensemble.append(ens_flux/nanmedian(ens_flux))
+		# temp_list and lc_ensemble are lists, and don't need to be returned because append() updates in place
+	
 	#----------------------------------------------------------------------------------------------
 	def apply_ensemble(self, lc, lc_ensemble, lc_corr):
 		"""
-		Apply the ensemble correction method to the target light curve
+		Apply the ensemble correction method to the target light curve 
 
 		Parameters:
-			lc (`TESSLightCurve` object): Lightcurve object for target obtained
-				from :func:`load_lightcurve`.
+			lc (`TESSLightCurve` object): Lightcurve object for target obtained from :func:`load_lightcurve`.
 			lc_ensemble (list): List of ensemble members flux as ndarrays
-			lc_corr (`TESSLightCurve` object): Lightcurve object which stores the ensemble
-				corrected flux values.
+			lc_corr (`TESSLightCurve` object): Lightcurve object which stores in `flux` the ensemble corrected flux values.
 
-		Returns:
-			lc_corr (`TESSLightCurve` object): The updated object with corrected flux values.
+        Returns: 
+            lc_corr (`TESSLightCurve` object): The updated object with corrected flux values;
+                the object must be returned explicitly because passed object values do not update in place
 
 		.. codeauthor:: Lindsey Carboneau
 		.. codeauthor:: Derek Buzasi
@@ -179,11 +178,12 @@ class EnsembleCorrector(BaseCorrector):
 		lc_medians = nanmedian(np.asarray(lc_ensemble), axis=0)
 
 		def func2(scalef, *args):
-			num1 = nansum(np.abs(np.diff(args[0] / (args[1] + scalef))))
-			denom1 = nanmedian(args[0] / (args[1] + scalef))
+			num1 = np.sum(np.abs(np.diff(np.divide(args[0],args[1]+scalef))))
+			denom1 = np.median(np.divide(args[0],args[1]+scalef))
 			return num1/denom1
 
-		res = minimize(func2, 1.0, args=(lc.flux, lc_medians))
+		scale0 = 1.0
+		res = minimize(func2, scale0, args=(lc.flux, lc_medians))
 		k_corr = res.x
 
 		# Correct the lightcurve:
@@ -191,7 +191,8 @@ class EnsembleCorrector(BaseCorrector):
 		lc_corr /= nanmedian(lc_corr.flux)
 		lc_corr *= nanmedian(lc.flux)
 		return lc_corr
-
+	
+	
 	#----------------------------------------------------------------------------------------------
 	def do_correction(self, lc):
 		"""
@@ -214,23 +215,29 @@ class EnsembleCorrector(BaseCorrector):
 		drange_lim = 1.0 # Limit on differenced range - not in log10!
 		drange_relfactor = 10 # Limit on differenced range, relative to target d.range.
 		frange_lim = 0.4 # Limit on flux range.
+		star_count = 5 # Number of stars wanted for ensemble.
 		min_star_count = 5 # Minimum number of stars to have in the ensemble.
 		max_neighbors = 100 # Maximal number of neighbors to check.
 
 		# Clean up the lightcurve by removing nans and ignoring data points with bad quality flags
 		# these values need to be removed, or they will affect the ensemble later
-		lc_quality_mask = ~TESSQualityFlags.filter(lc.quality, TESSQualityFlags.HARDEST_BITMASK)
-		lc.flux[lc_quality_mask] = np.NaN
+		og_time = lc.time.copy()
+		lc = lc.remove_nans()
+		lc_quality_mask = (lc.quality == 0)
+		lc.time = lc.time[lc_quality_mask]
+		lc.flux = lc.flux[lc_quality_mask]
+		lc.flux_err = lc.flux_err[lc_quality_mask]
 		lc_corr = lc.copy()
 
 		# Set up basic statistical parameters for the light curves.
 		# frange is the light curve range from the 5th to the 95th percentile,
 		# drange is the relative standard deviation of the differenced light curve (to whiten the noise)
 		target_flux_median = lc.meta['task']['mean_flux']
-		target_frange = np.diff(np.nanpercentile(lc.flux, [5, 95])) / target_flux_median
-		target_drange = nanstd(np.diff(lc.flux)) / target_flux_median
+		frange = (np.percentile(lc.flux, 95) - np.percentile(lc.flux, 5)) / target_flux_median
+		drange = np.std(np.diff(lc.flux)) / target_flux_median
+		lc.meta.update({'frange': frange, 'drange': drange})
 
-		logger.debug("Main target: drange=%f, frange=%f", target_drange, target_frange)
+		logger.debug("Main target: drange=%f, frange=%f", drange, frange)
 		logger.debug("lc size: %f", len(lc.flux))
 
 		# Query for a list of the nearest neigbors to test:
@@ -240,10 +247,9 @@ class EnsembleCorrector(BaseCorrector):
 		# Define variables to use in the loop to build the ensemble of stars
 		# List of star indexes to be included in the ensemble
 		temp_list = []
-		lc_ensemble = []
-
-		# Test values store current best correction for testing vs. additional ensemble members
-		# NOTE: this might be done more efficiently with further functionalization of the loop below and updated loop bounds/conditions!
+		bzetas = []
+        # Test values store current best correction for testing vs. additional ensemble members
+        # NOTE: this might be done more efficiently with further functionalization of the loop below and updated loop bounds/conditions!
 		test_corr = []
 		test_ens = []
 		test_list = []
@@ -251,39 +257,40 @@ class EnsembleCorrector(BaseCorrector):
 
 		# Start loop to build ensemble
 		ensemble_start = default_timer()
+		lc_ensemble = []
+		mtarget_flux = lc.flux - target_flux_median
 
 		# Loop through the neighbors to build the ensemble:
 		for next_star_index in nearby_stars:
 			# Get lightkurve for next star closest to target:
-			next_star_lc = self.load_lightcurve(next_star_index)
+			next_star_lc = self.load_lightcurve(next_star_index).remove_nans()
 
-			# Remove bad points by setting them to NaN:
-			next_star_lc_quality_mask = ~TESSQualityFlags.filter(next_star_lc.quality, TESSQualityFlags.HARDEST_BITMASK)
-			next_star_lc.flux[next_star_lc_quality_mask] = np.NaN
+			next_star_lc_quality_mask = (next_star_lc.quality == 0)
+			next_star_lc.time = next_star_lc.time[next_star_lc_quality_mask]
+			next_star_lc.flux = next_star_lc.flux[next_star_lc_quality_mask]
+			next_star_lc.flux_err = next_star_lc.flux_err[next_star_lc_quality_mask]
 
 			# Compute the rest of the statistical parameters for the next star to be added to the ensemble.
-			frange = np.diff(np.nanpercentile(next_star_lc.flux, [5, 95])) / next_star_lc.meta['task']['mean_flux']
-			drange = nanstd(np.diff(next_star_lc.flux)) / next_star_lc.meta['task']['mean_flux']
+			frange = (np.percentile(next_star_lc.flux, 95) - np.percentile(next_star_lc.flux, 5)) / next_star_lc.meta['task']['mean_flux']
+			drange = np.std(np.diff(next_star_lc.flux)) / next_star_lc.meta['task']['mean_flux']
+
+			next_star_lc.meta.update({'frange': frange, 'drange': drange})
 
 			logger.debug("drange=%f, frange=%f", drange, frange)
-			logger.debug("lc size: %f", len(next_star_lc))
+			logger.debug("lc size: %f", len(next_star_lc.flux))
 
 			# Stars are added to ensemble if they fulfill the requirements. These are (1) drange less than min_range, (2) drange less than 10 times the
 			# drange of the target (to ensure exclusion of relatively noisy stars), and frange less than 0.03 (to exclude highly variable stars)
-			if drange < drange_lim and drange < drange_relfactor*target_drange and frange < frange_lim:
+			if drange < drange_lim and drange < drange_relfactor*lc.meta['drange'] and frange < frange_lim:
 
-				# Add the star to the ensemble:
-				lc_add_ensemble, bzeta = self.add_ensemble_member(lc, next_star_lc)
-				temp_list.append({'priority:': next_star_index, 'starid': next_star_lc.targetid, 'bzeta': bzeta})
-				lc_ensemble.append(lc_add_ensemble)
-
+				self.add_ensemble_member(lc, next_star_lc, next_star_index, temp_list, lc_ensemble, bzetas)
 				# Pause the loop if we have reached the desired number of stars, and check the correction:
-				if len(temp_list) >= min_star_count:
-
-					if np.isnan(fom):
+				if len(temp_list) >= star_count:
+					
+					if fom is np.nan:
 						# the first time we hit the minimum ensemble size, try to correct the target
 						# storing all these as 'test' - we'll revert to these values if adding the next star doesn't 'surpass the test'
-						# `deepcopy` because otherwise it uses pointers and overwrites the value we need
+                        # `deepcopy` because otherwise it uses pointers and overwrites the value we need
 						test_corr = self.apply_ensemble(lc, lc_ensemble, lc_corr)
 						test_ens = copy.deepcopy(lc_ensemble)
 						test_list = copy.deepcopy(temp_list)
@@ -293,23 +300,29 @@ class EnsembleCorrector(BaseCorrector):
 						########
 						# NOTE: I think this can be more efficiently, but I'm scared to 'fix' what is currently working - LC
 						########
+						continue
+					
 					else:
 						# see if one more member makes the ensemble 'surpass the test'
 						lc_corr = self.apply_ensemble(lc, lc_ensemble, lc_corr)
 						fom = np.sum(np.abs(np.diff(lc_corr.flux)))
-
+						
 						if fom < test_fom:
 							# the correction "got better" (less noisy) so update and try against another additional member
 							test_corr = lc_corr
 							test_ens = lc_ensemble
 							test_list = temp_list
 							test_fom = fom
+							continue
 						else:
-							# adding the next neighbor did not improve the correction, so we're done
+                            # adding the next neighbor did not improve the correction, so we're done
 							lc_corr = test_corr
 							lc_ensemble = test_ens
 							temp_list = test_list
 							break
+
+					
+					#break
 
 		# Ensure that we reached the minimum number of stars in the ensemble:
 		if len(temp_list) < min_star_count:
@@ -317,7 +330,7 @@ class EnsembleCorrector(BaseCorrector):
 			return None, STATUS.ERROR
 
 		logger.info("Build ensemble, Time: %f", default_timer()-ensemble_start)
-		logger.debug("len(lc) vs len(ens): %f vs %f", len(lc), len(lc_ensemble[0]))
+		logger.debug("len(lc) vs len(ens): %f vs %f", len(lc.flux), len(lc_ensemble[0]))
 
 		# Convert to parts-per-million:
 		lc_corr = 1e6*(lc_corr/nanmedian(lc_corr.flux) - 1)
@@ -325,8 +338,8 @@ class EnsembleCorrector(BaseCorrector):
 		# We probably want to return additional information, including the list of stars in the ensemble, and potentially other things as well.
 		logger.info(temp_list)
 		self.ensemble_starlist = {
-			'starids': [tl['starid'] for tl in temp_list],
-			'bzetas': [tl['bzeta'] for tl in temp_list]
+			'starids': temp_list,
+			'bzetas' : bzetas
 		}
 
 		# Set additional headers for FITS output:
@@ -335,12 +348,31 @@ class EnsembleCorrector(BaseCorrector):
 		lc_corr.meta['additional_headers']['ENS_DREL'] = (drange_relfactor, 'Limit on relative diff. range')
 		lc_corr.meta['additional_headers']['ENS_RLIM'] = (frange_lim, 'Limit on flux range metric')
 
+
+        # Replace removed points with NaN's so the info can be saved to the FITS - without this, the BaseCorrector will raise an `IndexError`
+		if len(lc_corr.flux) != len(og_time):
+			fix_flux = np.asarray(lc_corr.flux.copy())
+			fix_err = np.asarray(lc_corr.flux_err.copy())
+			indices = np.array(np.where(np.isin(og_time, lc_corr.time, assume_unique=True, invert=True)))[0]
+			indices.tolist()
+			
+			for ind in indices:
+				fix_flux = np.insert(fix_flux, ind, np.nan)
+				fix_err = np.insert(fix_err, ind, np.nan)
+			
+			lc_corr.flux = fix_flux.tolist()
+			lc_corr.flux_err = fix_err.tolist()
+			lc_corr.time = og_time
+            
+
 		#------------------------------------------------------------------------------------------
 		if self.plot and self.debug:
+
 			fig = plt.figure()
 			ax = fig.add_subplot(111)
 			ax.plot(lc.time, nanmedian(np.asarray(lc_ensemble), axis=0), label='Medians')
 			save_figure(os.path.join(self.plot_folder(lc), 'ensemble_lc_medians'), fig=fig)
 			plt.close(fig)
 
+		logger.debug("Status of correction: {}".format((np.isnan(np.asarray(lc_corr.flux))).tolist().count(False)))
 		return lc_corr, STATUS.OK

--- a/corrections/utilities.py
+++ b/corrections/utilities.py
@@ -122,7 +122,7 @@ def rms_timescale(lc, timescale=3600/86400):
 
 	# Bin the timeseries to one hour:
 	indx = np.isfinite(lc.flux)
-	flux_bin, _, _ = binned_statistic(lc.time[indx], lc.flux[indx], nanmean, bins=bins)
+	flux_bin, _, _ = binned_statistic(lc.time, lc.flux, nanmean, bins=bins)
 
 	# Compute robust RMS value (MAD scaled to RMS)
 	return mad_to_sigma * nanmedian(np.abs(flux_bin - nanmedian(flux_bin)))

--- a/corrections/utilities.py
+++ b/corrections/utilities.py
@@ -121,8 +121,8 @@ def rms_timescale(lc, timescale=3600/86400):
 	bins = np.append(bins, time_max)
 
 	# Bin the timeseries to one hour:
-	indx = np.isfinite(lc.flux)
-	flux_bin, _, _ = binned_statistic(lc.time, lc.flux, nanmean, bins=bins)
+	indx = np.isfinite(lc.time) & np.isfinite(lc.flux)
+	flux_bin, _, _ = binned_statistic(lc.time[indx], lc.flux[indx], nanmean, bins=bins)
 
 	# Compute robust RMS value (MAD scaled to RMS)
 	return mad_to_sigma * nanmedian(np.abs(flux_bin - nanmedian(flux_bin)))


### PR DESCRIPTION
This version is working!  I can continue checking some of the other optimizations, but I'm currently seeing ensemble corrections taking ~0.36 seconds on my laptop - if we're looking for more speed in the future this might be a good target but the logic is stubbornly delicate 