### PR TITLE
Sanity checks

### DIFF
--- a/corrections/BaseCorrector.py
+++ b/corrections/BaseCorrector.py
@@ -17,7 +17,7 @@ import sqlite3
 import tempfile
 import numpy as np
 from timeit import default_timer
-from bottleneck import nanmedian, nanvar
+from bottleneck import nanmedian, nanvar, allnan
 from astropy.io import fits
 from lightkurve import TessLightCurve
 from .plots import plt, save_figure
@@ -270,6 +270,12 @@ class BaseCorrector(object):
 
 		# Do sanity checks and calculate diagnostics:
 		if status in (STATUS.OK, STATUS.WARNING):
+			# Simple check that entire lightcurve is not NaN:
+			if allnan(lc_corr.flux):
+				raise ValueError("Final lightcurve is all NaNs")
+			if allnan(lc_corr.flux_err):
+				raise ValueError("Final lightcurve errors is all NaNs")
+
 			# Calculate diagnostics:
 			details['variance'] = nanvar(lc_corr.flux, ddof=1)
 			details['rms_hour'] = rms_timescale(lc_corr, timescale=3600/86400)

--- a/corrections/ensemble.py
+++ b/corrections/ensemble.py
@@ -194,7 +194,11 @@ class EnsembleCorrector(BaseCorrector):
 			return num1/denom1
 
 		res = minimize(func2, 1.0, args=(lc.flux, lc_medians))
-		k_corr = res.x
+		k_corr = float(res.x)
+
+		# Sanity checks:
+		if np.any(k_corr + lc_medians <= 0):
+			raise Exception('Sanity check: Optimization becomes negative')
 
 		# Correct the lightcurve:
 		lc_corr /= k_corr + lc_medians


### PR DESCRIPTION
Simple sanity checks which should catch the most crazy things that are caused by strange input light curves, that should not pass through the corrections.

Things like corrections returning all NaNs or ensuring that light curves are not "flipped" by accident.